### PR TITLE
Extend simple_print example by the possibility to read from STDIN.

### DIFF
--- a/capture.c
+++ b/capture.c
@@ -60,9 +60,9 @@ ws_capture_t *ws_capture_open_offline(const char *path, int flags, int *err, cha
     cfile.filename = g_strdup(path);
     /*if ((flags & WS_CAPTURE_SEQUENTIAL) == WS_CAPTURE_SEQUENTIAL) {*/
     ws_buffer_init(&buf, 1500);
+    gboolean do_random = (str_cmp(path, "-") == 0) ? FALSE : TRUE;
 
-
-    cfile.wth = wtap_open_offline(cfile.filename, WTAP_TYPE_AUTO, &_err, &_err_info, TRUE);
+    cfile.wth = wtap_open_offline(cfile.filename, WTAP_TYPE_AUTO, &_err, &_err_info, do_random);
     if (cfile.wth == NULL) {
         PROVIDE_ERRORS;
         return NULL;

--- a/capture.c
+++ b/capture.c
@@ -60,7 +60,7 @@ ws_capture_t *ws_capture_open_offline(const char *path, int flags, int *err, cha
     cfile.filename = g_strdup(path);
     /*if ((flags & WS_CAPTURE_SEQUENTIAL) == WS_CAPTURE_SEQUENTIAL) {*/
     ws_buffer_init(&buf, 1500);
-    gboolean do_random = (str_cmp(path, "-") == 0) ? FALSE : TRUE;
+    gboolean do_random = (strcmp(path, "-") == 0) ? FALSE : TRUE;
 
     cfile.wth = wtap_open_offline(cfile.filename, WTAP_TYPE_AUTO, &_err, &_err_info, do_random);
     if (cfile.wth == NULL) {

--- a/examples/00-simple-print.c
+++ b/examples/00-simple-print.c
@@ -51,7 +51,7 @@ int main(int argc, char *argv[]) {
 
     filename = argv[optind];
 
-    if (access(filename, F_OK) == -1) {
+    if (strcmp(filename, "-") != 0 && access(filename, F_OK) == -1) {
         fprintf(stderr, "File '%s' doesn't exist.\n", filename);
         return 1;
     }


### PR DESCRIPTION
We need to disable the opening of STDIN for random access, or WTAP_ERR_RANDOM_OPEN_STDIN -16, compare wtap.h, is thrown.

wtap_open_offline() already takes care very nicely of reading from stdin, we just need some minor adjustments in liblibwireshark.